### PR TITLE
ci: Add GitHub Actions for testing build and deployment to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI/CD
+
+on:
+  push:
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build Docker image
+      run: |
+        docker build . \
+          --file simple/Dockerfile \
+          --tag lukasheinrich/folding:$GITHUB_SHA \
+          --compress
+        docker images

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  build-and-publish:
+    name: Build and publish Docker images to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build and Publish to Registry
+      if: "! ${{ startsWith(github.ref, 'refs/tags/') }}"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: lukasheinrich/folding
+        dockerfile: simple/Dockerfile
+        tags: latest,simple
+    - name: Build and Publish to Registry with Release Tag
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: lukasheinrich/folding
+        dockerfile: simple/Dockerfile
+        tags: latest,latest-stable,simple
+        tag_with_ref: true

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# folding-at-home-docker
-docker images for folding @ home
+# Folding@home Docker images
+
+Docker images for [Folding@home](https://foldingathome.org/)
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/lukasheinrich/folding)](https://hub.docker.com/r/lukasheinrich/folding)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/lukasheinrich/folding/simple)](https://hub.docker.com/r/lukasheinrich/folding/tags?name=simple)
+
+## Build image
 
 ```
 docker build -t lukasheinrich/folding:simple . -f simple/Dockerfile
 ```
 
-Usage
+## Usage
 
 ```
 docker run lukasheinrich/folding:simple


### PR DESCRIPTION
Add CI using GitHub Actions to test the build and then deploy the build to Docker Hub with the tags `latest` and `simple` (if the push that triggers the build is a tag push then the image will also be labeled with `latest-stable` and the tag).

This requires the following secrets be added to the GitHub repo:

- `DOCKER_USERNAME`
- `DOCKER_PASSWORD`

Also additionally add hyperlinks to [Folding@home](https://foldingathome.org/) and information on the Docker image `simple` tag:

[![Docker Pulls](https://img.shields.io/docker/pulls/lukasheinrich/folding)](https://hub.docker.com/r/lukasheinrich/folding) [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/lukasheinrich/folding/simple)](https://hub.docker.com/r/lukasheinrich/folding/tags?name=simple)
 