### PR TITLE
refactor: Apply Hadolint corrections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,16 @@ FROM nvidia/opencl:runtime-ubuntu18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get -y update
-RUN apt-get -y install ocl-icd-opencl-dev
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends ocl-icd-opencl-dev && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 ADD https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.5/fahclient_7.5.1_amd64.deb /tmp
-RUN dpkg -i /tmp/fahclient_7.5.1_amd64.deb || exit 0
-RUN rm /tmp/fahclient_7.5.1_amd64.deb
+RUN dpkg -i /tmp/fahclient_7.5.1_amd64.deb || exit 0 && \
+  rm /tmp/fahclient_7.5.1_amd64.deb
 
 WORKDIR /root
 VOLUME /root
 
-CMD FAHClient --user=CERN --team=38188 --gpu=true --smp=true
+CMD ["FAHClient", "--user=CERN", "--team=38188", "--gpu=true", "--smp=true"]

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ docker build -t lukasheinrich/folding:latest . -f Dockerfile
 ## Usage
 
 ```
-docker run lukasheinrich/folding:latest
+docker run --rm lukasheinrich/folding:latest
 ```


### PR DESCRIPTION
Apply [Hadolint](https://github.com/hadolint/hadolint) corrections to the Dockerfile and reduce `RUN` commands to reduce image size from the current [`267 MB`](https://github.com/lukasheinrich/folding-at-home-docker/runs/523313722?check_suite_focus=true#step:5:5) to [`101 MB`](https://github.com/lukasheinrich/folding-at-home-docker/pull/8/checks#step:5:5).

c.f.
- https://github.com/hadolint/hadolint/wiki/DL3009
- https://github.com/hadolint/hadolint/wiki/DL3015
- https://github.com/hadolint/hadolint/wiki/DL3025